### PR TITLE
修复解析{{}时无响应且不提示错误的BUG

### DIFF
--- a/src/main/java/com/compiler/principle/lab/logic/grammar/LLParser.java
+++ b/src/main/java/com/compiler/principle/lab/logic/grammar/LLParser.java
@@ -94,6 +94,8 @@ public class LLParser {
         List<TerminalSymbol> symbols = new ArrayList<>();
         tokenItems.stream().map(t -> new TerminalSymbol(t.getToken().getType(), t.getToken())).forEach(symbols::add);
         symbols.add(END_SYMBOL);
+        TokenItem last = tokenItems.get(tokenItems.size()-1);
+        tokenItems.add(new TokenItem(new Token("END"),"END",last.getColumn(),last.getRow()));
         if (analyser.hasError()) {
             mLexError = analyser.getErrorMessage();
             mLexHasError = true;


### PR DESCRIPTION
应该是因为未添加结束符号导致List访问越界